### PR TITLE
Use three-digit version numbers to support semantic versionining

### DIFF
--- a/marvin.brain.springai/pom.xml
+++ b/marvin.brain.springai/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.brain.springai</artifactId>

--- a/marvin.environment.openhab/pom.xml
+++ b/marvin.environment.openhab/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.environment.openhab</artifactId>

--- a/marvin.interaction.web/pom.xml
+++ b/marvin.interaction.web/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.interaction.web</artifactId>

--- a/marvin.internet.google/pom.xml
+++ b/marvin.internet.google/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.internet.google</artifactId>

--- a/marvin.library.bookstack/pom.xml
+++ b/marvin.library.bookstack/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.library.bookstack</artifactId>

--- a/marvin.persistence/pom.xml
+++ b/marvin.persistence/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.persistence</artifactId>

--- a/marvin.robot.core/pom.xml
+++ b/marvin.robot.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.robot.core</artifactId>

--- a/marvin.speech.openai/pom.xml
+++ b/marvin.speech.openai/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.assetvisor</groupId>
     <artifactId>marvin.robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>marvin.speech.openai</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,11 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.assetvisor</groupId>
+
   <artifactId>marvin.robot</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
+
   <modules>
     <module>marvin.brain.springai</module>
     <module>marvin.environment.openhab</module>


### PR DESCRIPTION
Let's switch to three-digit numbers to follow best practices in software maintenance