### PR TITLE
Push to docker hub only on master branch builds

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,12 +38,14 @@ jobs:
           docker inspect --format='{{json .Config.Labels}}' marvin:latest | jq
 
       - name: Login to docker hub
+        if: github.ref == 'refs/heads/main'  # Only push if the branch is main
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push Docker Image
+        if: github.ref == 'refs/heads/main'  # Only push if the branch is main
         run: |
           docker tag marvin:${{ env.VERSION }} ${{ secrets.DOCKER_HUB_USERNAME }}/marvin:${{ env.VERSION }}
           docker tag marvin:latest             ${{ secrets.DOCKER_HUB_USERNAME }}/marvin:latest


### PR DESCRIPTION
Secure credentials are not available to branch builds.