### PR TITLE
This repo uses a 'master' branch, not a 'main'

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,14 +38,14 @@ jobs:
           docker inspect --format='{{json .Config.Labels}}' marvin:latest | jq
 
       - name: Login to docker hub
-        if: github.ref == 'refs/heads/main'  # Only push if the branch is main
+        if: github.ref == 'refs/heads/master'  # Only push if the branch is master
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push Docker Image
-        if: github.ref == 'refs/heads/main'  # Only push if the branch is main
+        if: github.ref == 'refs/heads/master'  # Only push if the branch is master
         run: |
           docker tag marvin:${{ env.VERSION }} ${{ secrets.DOCKER_HUB_USERNAME }}/marvin:${{ env.VERSION }}
           docker tag marvin:latest             ${{ secrets.DOCKER_HUB_USERNAME }}/marvin:latest


### PR DESCRIPTION
With the last patch ( https://github.com/geir-eilertsen/marvin.robot/pull/88 ), no images get pushed to docker hub at all. Rectify this.