### PR TITLE
Implemented Cassandra migration on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,8 @@ that contains the application.yml configuration file.
 
 The Spring AI implemented brain is in the marvin.brain.springai module. It needs a vector store to work.
 
-Use a docker container to run the Cassandra vector store. There is a docker compose file at project root.
-
-When cassandra is up and running you have to create a keyspace called springframework.
-You can do this by running the following command:
-
-```
-CREATE KEYSPACE springframework WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };
-```
+Use a docker container to run the Cassandra vector store. There is a docker compose file at project root. Keyspaces and
+tables will be created and updated when the application starts.
 
 When the application has started, open http://localhost:9090 in your browser. You will be redirected to the OAuth2 login page.
 

--- a/marvin.interaction.web/src/main/resources/application.yml
+++ b/marvin.interaction.web/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     vectorstore:
       cassandra:
         initialize-schema: true
-        keyspace: springframework
+        keyspace: ${spring.cassandra.keyspace-name}
     openai:
       api-key: ${OPENAI_APIKEY} # OpenAI API key, get your own at https://platform.openai.com
   cassandra:
@@ -20,7 +20,7 @@ spring:
     contact-points: ${VECTORDB_ADDRESS}
     password: admin
     username: admin
-    schema-action: create_if_not_exists
+    schema-action: none
     port: 9042
   security:
     oauth2:
@@ -39,6 +39,10 @@ spring:
             clientSecret: ${GOOGLE_CLIENT_SECRET}
 server:
   port: 9090
+
+cassandra:
+  migration:
+    keyspace-name: ${spring.cassandra.keyspace-name}
 
 openhab:
   url: ${OPENHAB_URL}

--- a/marvin.persistence/pom.xml
+++ b/marvin.persistence/pom.xml
@@ -22,5 +22,10 @@
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-cassandra</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.cognitor.cassandra</groupId>
+      <artifactId>cassandra-migration-spring-boot-starter</artifactId>
+      <version>2.6.1_v4</version>
+    </dependency>
   </dependencies>
 </project>

--- a/marvin.persistence/src/main/java/com/assetvisor/marvin/persistence/config/CassandraConfig.java
+++ b/marvin.persistence/src/main/java/com/assetvisor/marvin/persistence/config/CassandraConfig.java
@@ -1,33 +1,35 @@
 package com.assetvisor.marvin.persistence.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.CqlSessionBuilder;
+import org.cognitor.cassandra.migration.spring.CassandraMigrationAutoConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.cassandra.config.CqlSessionFactoryBean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.cassandra.core.cql.CqlTemplate;
 import org.springframework.data.cassandra.core.cql.session.DefaultSessionFactory;
 
 @Configuration
 public class CassandraConfig {
 
-    @Value("${spring.cassandra.contact-points}")
-    private String contactPoints;
-    @Value("${spring.cassandra.keyspace-name}")
-    private String keyspaceName;
-    @Value("${spring.cassandra.local-datacenter}")
-    private String localDatacenter;
-
     @Bean
-    public CqlSessionFactoryBean cqlSessionFactoryBean() {
-        CqlSessionFactoryBean sessionFactoryBean = new CqlSessionFactoryBean();
-        sessionFactoryBean.setContactPoints(contactPoints);
-        sessionFactoryBean.setKeyspaceName(keyspaceName);
-        sessionFactoryBean.setLocalDatacenter(localDatacenter);
-        return sessionFactoryBean;
+    @Qualifier(CassandraMigrationAutoConfiguration.CQL_SESSION_BEAN_NAME)
+    public CqlSession cassandraMigrationCqlSession(CqlSessionBuilder cqlSessionBuilder) {
+        return cqlSessionBuilder.withKeyspace((CqlIdentifier) null).build();
     }
 
     @Bean
-    public CqlTemplate cqlTemplate(CqlSessionFactoryBean cqlSessionFactoryBean) throws Exception {
-        return new CqlTemplate(new DefaultSessionFactory(cqlSessionFactoryBean.getObject()));
+    @Primary
+    @DependsOn(CassandraMigrationAutoConfiguration.MIGRATION_TASK_BEAN_NAME)
+    public CqlSession cqlSession(CqlSessionBuilder cqlSessionBuilder) {
+        return cqlSessionBuilder.build();
+    }
+
+    @Bean
+    public CqlTemplate cqlTemplate(CqlSession cqlSession) {
+        return new CqlTemplate(new DefaultSessionFactory(cqlSession));
     }
 }

--- a/marvin.persistence/src/main/resources/cassandra/migration/1_initial.cql
+++ b/marvin.persistence/src/main/resources/cassandra/migration/1_initial.cql
@@ -1,0 +1,3 @@
+CREATE TABLE IF NOT EXISTS environmentdescriptionentry (id uuid, description text, PRIMARY KEY (id));
+CREATE TABLE IF NOT EXISTS personentry (id uuid, person_name text, email text, relation text, github_id text, google_id text, PRIMARY KEY (id));
+CREATE TABLE IF NOT EXISTS notebookentry (id uuid, created_date timestamp, note_date timestamp, note text, PRIMARY KEY (id));


### PR DESCRIPTION
Before implementing a local user management (login without OAuth2), I wanted the Cassandra store to be able to update itself (as the personentry table will require a password field). This PR uses the cassandra-migration project. On startup, all scripts from the src/main/resources/cassandra/migration directory that haven't been run yet run in order.

Positive side effect: The keyspace is created on startup as well, if it doesn't exist yet. The default parameters for replication happen to be the same as required by the former README.

If the database is already set up when running with cassandra-migration for the first time, nothing happens since the first script does CREATE TABLE IF NOT EXISTS.

This PR also contains https://github.com/geir-eilertsen/marvin.robot/pull/95