### PR TITLE
Adapted to latest spring-ai snapshot, fixed variable in pom.xml

### DIFF
--- a/marvin.speech.openai/src/main/java/com/assetvisor/marvin/speech/springai/config/SpringAiSpeechConfig.java
+++ b/marvin.speech.openai/src/main/java/com/assetvisor/marvin/speech/springai/config/SpringAiSpeechConfig.java
@@ -17,7 +17,9 @@ public class SpringAiSpeechConfig {
 
     @Bean
     public OpenAiAudioApi openAiAudioApi() {
-        return new OpenAiAudioApi(openAiApiKey);
+        return OpenAiAudioApi.builder()
+            .apiKey(openAiApiKey)
+            .build();
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>${exec-maven-plugin.version</version>
+          <version>${exec-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Apparently spring-ai changed the constructor of OpenAiAudioApi. Also fixed missing "}" in pom.xml