### PR TITLE
Implemented local user directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/jsLibraryMappings.xml
+.idea/codeStyles/
 .idea/compiler.xml
 .idea/encodings.xml
 .idea/misc.xml

--- a/marvin.interaction.web/pom.xml
+++ b/marvin.interaction.web/pom.xml
@@ -86,6 +86,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -103,6 +107,11 @@
       <groupId>org.webjars</groupId>
       <artifactId>bootstrap</artifactId>
       <version>5.3.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>fortawesome__fontawesome-free</artifactId>
+      <version>6.7.2</version>
     </dependency>
     <dependency>
       <groupId>org.webjars</groupId>

--- a/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/adapters/AuthenticationEventHandlingAdapter.java
+++ b/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/adapters/AuthenticationEventHandlingAdapter.java
@@ -4,6 +4,7 @@ import com.assetvisor.marvin.robot.application.PersonEnteredUseCase;
 import com.assetvisor.marvin.robot.domain.relationships.Person;
 import jakarta.annotation.Resource;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.oauth2.client.authentication.OAuth2LoginAuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -32,6 +33,9 @@ public class AuthenticationEventHandlingAdapter {
             ),
                 id
             );
+        }
+        if (source instanceof UsernamePasswordAuthenticationToken token) {
+            return new Person.PersonId(Person.IdType.LOCAL, token.getName());
         }
         throw new IllegalArgumentException("Unsupported event source: " + event.getSource());
     }

--- a/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/config/PersistingPersonsUserDetailsService.java
+++ b/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/config/PersistingPersonsUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.assetvisor.marvin.interaction.web.config;
+
+import com.assetvisor.marvin.robot.domain.relationships.ForPersistingPerson;
+import jakarta.annotation.Resource;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PersistingPersonsUserDetailsService implements UserDetailsService {
+
+    @Resource
+    private ForPersistingPerson forPersistingPerson;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        var person = forPersistingPerson.byEmail(username);
+        if (person == null) {
+            throw new UsernameNotFoundException(username);
+        }
+
+        return User.builder()
+            .username(person.email())
+            .password(person.password())
+            .build();
+    }
+}

--- a/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/config/WebConfiguration.java
+++ b/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/config/WebConfiguration.java
@@ -1,15 +1,25 @@
 package com.assetvisor.marvin.interaction.web.config;
 
 import com.assetvisor.marvin.interaction.web.adapters.OAuth2UserServiceToMarvinAdapter;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.ResourceHandlerRegistrationCustomizer;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @EnableWebSecurity
 @Configuration
@@ -17,13 +27,28 @@ public class WebConfiguration {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, OAuth2UserServiceToMarvinAdapter userService) throws Exception {
-        http.authorizeHttpRequests((requests) -> requests
-                .requestMatchers("/", "/whatsapp", "/error", "/webjars").permitAll()
-                .anyRequest().authenticated())
-            .logout(logout -> logout.logoutSuccessUrl("/").permitAll())
-            .oauth2Login(oauth -> oauth.userInfoEndpoint(userInfo -> userInfo.userService(userService)))
-            .csrf(AbstractHttpConfigurer::disable);
-        return http.build();
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(requests -> requests
+                .requestMatchers("/whatsapp", "/error", "/webjars/**", "/styles.css", "/script.js").permitAll()
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .loginPage("/login")
+                .loginProcessingUrl("/login/authenticate")
+                .defaultSuccessUrl("/")
+                .permitAll()
+            )
+            .oauth2Login(oauth -> oauth
+                .loginPage("/login")
+                .userInfoEndpoint(userInfo -> userInfo.userService(userService))
+                .permitAll()
+            )
+            .logout(logout -> logout
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/login")
+            )
+            .build();
     }
 
     @Bean

--- a/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/controllers/LoginController.java
+++ b/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/controllers/LoginController.java
@@ -1,0 +1,16 @@
+package com.assetvisor.marvin.interaction.web.controllers;
+
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.ModelAndView;
+
+@CrossOrigin
+@RestController
+public class LoginController {
+
+    @GetMapping("/login")
+    public ModelAndView login() {
+        return new ModelAndView("login");
+    }
+}

--- a/marvin.interaction.web/src/main/resources/application.yml
+++ b/marvin.interaction.web/src/main/resources/application.yml
@@ -37,6 +37,9 @@ spring:
             redirect-uri: ${EXTERNAL_ADDRESS}/login/oauth2/code/google
             clientId: ${GOOGLE_CLIENT_ID}
             clientSecret: ${GOOGLE_CLIENT_SECRET}
+  web:
+    resources:
+      add-mappings: true
 server:
   port: 9090
 

--- a/marvin.interaction.web/src/main/resources/static/index.html
+++ b/marvin.interaction.web/src/main/resources/static/index.html
@@ -23,16 +23,8 @@
   <title>Chat with Marvin</title>
 </head>
 <body>
-<div class="container unauthenticated">
-  <div>
-    With GitHub: <a href="/oauth2/authorization/github">click here</a>
-  </div>
-  <div>
-    With Google: <a href="/oauth2/authorization/google">click here</a>
-  </div>
-</div>
 
-<div class="container authenticated" style="display:none">
+<div class="container">
 <!-- Menu panel for recording buttons and audio player -->
 <div class="menu-panel">
   <div class="button-panel">
@@ -42,7 +34,7 @@
   <audio id="audioPlayer" controls class="audio-player"></audio>
   <span id="user"></span>
   <div>
-    <button onClick="logout()">Logout</button>
+    <button onclick="window.location.href='/logout'">Logout</button>
   </div>
 </div>
 
@@ -57,21 +49,5 @@
 
 <script type="module" src="script.js"></script>
 </div>
-<script type="text/javascript">
-  $.get("/user", function(data) {
-    $("#user").html(data.name);
-    $(".unauthenticated").hide()
-    $(".authenticated").show()
-  });
-
-  var logout = function() {
-    $.post("/logout", function() {
-      $("#user").html('');
-      $(".unauthenticated").show();
-      $(".authenticated").hide();
-    })
-    return true;
-  }
-</script>
 </body>
 </html>

--- a/marvin.interaction.web/src/main/resources/static/styles.css
+++ b/marvin.interaction.web/src/main/resources/static/styles.css
@@ -96,3 +96,21 @@ img {
   cursor: pointer;
   margin-right: 10px;
 }
+
+.btn-login {
+  font-size: 0.9rem;
+  letter-spacing: 0.05rem;
+  padding: 0.75rem 1rem;
+}
+
+.btn-google {
+  color: white !important;
+  background-color: #ea4335 !important;
+  border-color: #ea4335 !important;
+}
+
+.btn-github {
+  color: white !important;
+  background-color: #24292e !important;
+  border-color: #24292e !important;
+}

--- a/marvin.interaction.web/src/main/resources/templates/login.html
+++ b/marvin.interaction.web/src/main/resources/templates/login.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<link rel="stylesheet" th:href="@{styles.css}">
+<link rel="stylesheet" type="text/css" th:href="@{/webjars/fortawesome__fontawesome-free/css/all.css}"/>
+<link rel="stylesheet" type="text/css" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}"/>
+<script type="text/javascript" th:src="@{/webjars/jquery/jquery.min.js}"></script>
+<script type="text/javascript" th:src="@{/webjars/bootstrap/js/bootstrap.min.js}"></script>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chat with Marvin - Sign In</title>
+</head>
+<body>
+<div class="container">
+    <div class="row">
+        <div class="col-sm-9 col-md-7 col-lg-5 mx-auto">
+            <div class="card border-0 shadow rounded-3 my-5">
+                <div class="card-body p-4 p-sm-5">
+                    <form th:action="@{/login/authenticate}" method="post">
+                        <div class="alert alert-danger" role="alert" th:if="${param.error}">
+                            Invalid credentials.
+                        </div>
+
+                        <div class="form-floating mb-3">
+                            <input type="email" class="form-control" id="username" name="username" placeholder="name@example.com">
+                            <label for="username">Email address</label>
+                        </div>
+                        <div class="form-floating mb-3">
+                            <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                            <label for="password">Password</label>
+                        </div>
+
+                        <div class="d-grid">
+                            <button class="btn btn-primary btn-login text-uppercase fw-bold" type="submit">Sign
+                                in</button>
+                        </div>
+                        <hr class="my-4">
+                    </form>
+
+                    <div class="d-grid mb-2">
+                        <a class="btn btn-github btn-login text-uppercase fw-bold"
+                           th:href="@{/oauth2/authorization/github}">
+                            <i class="fab fa-github me-2"></i> Sign in with Github
+                        </a>
+                    </div>
+                    <div class="d-grid">
+                        <a class="btn btn-google btn-login text-uppercase fw-bold" type="button"
+                           th:href="@{/oauth2/authorization/google}">
+                            <i class="fab fa-google me-2"></i> Sign in with Google
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/marvin.persistence/src/main/java/com/assetvisor/marvin/persistence/adapters/cassandra/relationships/PersonEntry.java
+++ b/marvin.persistence/src/main/java/com/assetvisor/marvin/persistence/adapters/cassandra/relationships/PersonEntry.java
@@ -30,6 +30,9 @@ public class PersonEntry {
     @Column("google_id")
     private String googleId;
 
+    @Column("password")
+    private String password;
+
     public PersonEntry() {
     }
 
@@ -79,5 +82,13 @@ public class PersonEntry {
 
     public void setGoogleId(String googleId) {
         this.googleId = googleId;
+    }
+
+    public Optional<String> getPassword() {
+        return Optional.ofNullable(password);
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 }

--- a/marvin.persistence/src/main/resources/cassandra/migration/2_addPassword.cql
+++ b/marvin.persistence/src/main/resources/cassandra/migration/2_addPassword.cql
@@ -1,0 +1,1 @@
+ALTER TABLE personentry ADD (password text);

--- a/marvin.robot.core/src/main/java/com/assetvisor/marvin/robot/application/services/RelationshipService.java
+++ b/marvin.robot.core/src/main/java/com/assetvisor/marvin/robot/application/services/RelationshipService.java
@@ -34,6 +34,7 @@ public class RelationshipService implements PersonWantsToEnterUseCase, PersonEnt
                     UUID.randomUUID().toString(),
                     personUco.getName(),
                     personUco.getEmail(),
+                    null,
                     STRANGER,
                     List.of(
                         new Person.PersonId(

--- a/marvin.robot.core/src/main/java/com/assetvisor/marvin/robot/domain/relationships/Person.java
+++ b/marvin.robot.core/src/main/java/com/assetvisor/marvin/robot/domain/relationships/Person.java
@@ -6,6 +6,7 @@ public record Person(
     String id,
     String name,
     String email,
+    String password,
     Relationship relationship,
     List<PersonId> externalIds
 ) {


### PR DESCRIPTION
This PR is based on https://github.com/geir-eilertsen/marvin.robot/pull/96

Implemented a new login page using thymeleaf templates. Added font-awesome-free as a webjar dependency to display Gitrhub and Google logos. Added login with email and password. Updated README.

It is possible to use the same email address for all login mechanisms. If you first add a local user and login with OAuth later, the OAuth provider id is added to the personentry record. If you first login with OAuth and add a password later, you can use that email address to login locally.