### PR TITLE
Use -parameters when compiling to omit RequestParam and PathParam values

### DIFF
--- a/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/controllers/WorkshopController.java
+++ b/marvin.interaction.web/src/main/java/com/assetvisor/marvin/interaction/web/controllers/WorkshopController.java
@@ -6,14 +6,14 @@ import com.assetvisor.marvin.robot.application.GetEnvironmentDescriptionsUseCase
 import com.assetvisor.marvin.robot.application.InitialiseUseCase;
 import com.assetvisor.marvin.robot.domain.environment.EnvironmentDescription;
 import jakarta.annotation.Resource;
-import java.security.Principal;
-import java.util.List;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @CrossOrigin
 @RestController
@@ -28,30 +28,23 @@ public class WorkshopController {
     @Resource
     private DeleteEnvironmentDescriptionUseCase deleteEnvironmentDescriptionUseCase;
 
-
-    @PostMapping("/initialise")
-    public void initialise(Principal principal) {
+    @GetMapping("/initialise")
+    public void initialise() {
         initialiseUseCase.initialise();
     }
 
     @PostMapping("/environment")
-    public void addEnvironmentDescription(
-        Principal principal,
-        @RequestParam(value = "description") String description
-    ) {
+    public void addEnvironmentDescription(@RequestParam String description) {
         addEnvironmentDescriptionUseCase.add(description);
     }
 
     @GetMapping("/environment")
-    public List<EnvironmentDescription> getEnvironmentDescriptions(Principal principal) {
+    public List<EnvironmentDescription> getEnvironmentDescriptions() {
         return getEnvironmentDescriptionsUseCase.all();
     }
 
     @DeleteMapping("/environment")
-    public void deleteEnvironmentDescription(
-        Principal principal,
-        @RequestParam(value = "id") String id
-    ) {
+    public void deleteEnvironmentDescription(@RequestParam String id) {
         deleteEnvironmentDescriptionUseCase.delete(id);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,16 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <compilerArg>-parameters</compilerArg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-help-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
When using -parameters to the Java compiler, it isn't necessary to duplicate the parameters' names in @RequestParam and @PathVariable.

The mapping for /initialise has also changed to GET method. This makes it easier to call the initialise endpoint from the same browser after logging in.