### PR TITLE
Start marvin only after cassandra is ready for service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,12 @@ services:
     environment:
       - CASSANDRA_USER=admin
       - CASSANDRA_PASSWORD=admin
+    healthcheck:
+      # Report "healthy" only when cassandra is ready for service
+      test: ["CMD", "cqlsh", "-e", "DESCRIBE KEYSPACES"]
+      interval: 10s
+      retries: 5
+      start_period: 20s
     volumes:
       - data_cassandra:/var/lib/cassandra
     networks:
@@ -66,6 +72,9 @@ services:
       GOOGLE_CLIENT_ID: $GOOGLE_CLIENT_ID
       GOOGLE_CLIENT_SECRET: $GOOGLE_CLIENT_SECRET
       VECTORDB_ADDRESS: cassandra
+    depends_on:
+      cassandra:
+        condition: service_healthy
     volumes:
       - /home/cnb:/home/cnb
     networks:


### PR DESCRIPTION
Also discussed on issue #91 , marvin fails to start of it is launched to soon while cassandra is not yet ready for service.

This is something I noticed on my setup where I completely tear down the compose project, thereby terminating cassandra, and try a fresh startup. With the healthcheck and the dependency, marvin is able to connect to the cassandra service.