### PR TITLE
Using injection-safe path parameters and type tokens in OpenHAB rest clients

### DIFF
--- a/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/functions/GetItemStateFunction.java
+++ b/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/functions/GetItemStateFunction.java
@@ -41,7 +41,7 @@ public class GetItemStateFunction implements Tool<Request, Response> {
         LOG.info(request);
         try {
             String body = openhabRestClient.get()
-                .uri("items/" + request.itemId + "/state")
+                .uri("items/{itemId}/state", request.itemId)
                 .accept(MediaType.TEXT_PLAIN)
                 .retrieve()
                 .body(String.class);

--- a/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/functions/GetRuleActionsFunction.java
+++ b/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/functions/GetRuleActionsFunction.java
@@ -3,15 +3,17 @@ package com.assetvisor.marvin.environment.openhab.functions;
 import com.assetvisor.marvin.environment.openhab.functions.GetRuleActionsFunction.Request;
 import com.assetvisor.marvin.robot.domain.tools.Tool;
 import jakarta.annotation.Resource;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 @Profile("environment-openhab")
@@ -41,12 +43,11 @@ public class GetRuleActionsFunction implements Tool<Request, List<Map<String, Ob
     public List<Map<String, Object>> apply(Request request) {
         LOG.info(request);
         try {
-            List<Map<String, Object>> body = openhabRestClient.get()
-                .uri("rules/" + request.ruleId + "/actions")
+            return openhabRestClient.get()
+                .uri("rules/{ruleId}/actions", request.ruleId)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .body(List.class);
-            return body;
+                .body(LIST_OF_MAP_TYPE);
         } catch (HttpClientErrorException e) {
             return List.of();
         }
@@ -54,4 +55,7 @@ public class GetRuleActionsFunction implements Tool<Request, List<Map<String, Ob
 
     public record Request(String ruleId) {}
     public record Response(String code) {}
+
+    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_OF_MAP_TYPE =
+        new ParameterizedTypeReference<>() {};
 }

--- a/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/functions/SendCommandFunction.java
+++ b/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/functions/SendCommandFunction.java
@@ -46,7 +46,7 @@ public class SendCommandFunction implements Tool<Command, Response> {
         LOG.info(command);
         try {
             ResponseEntity<Void> responseEntity = openhabRestClient.post()
-                .uri("items/" + command.itemId)
+                .uri("items/{itemId}", command.itemId)
                 .contentType(MediaType.TEXT_PLAIN)
                 .body(command.command)
                 .retrieve()

--- a/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/restclient/GetEventPublishingItemsRestClient.java
+++ b/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/restclient/GetEventPublishingItemsRestClient.java
@@ -1,14 +1,16 @@
 package com.assetvisor.marvin.environment.openhab.restclient;
 
 import jakarta.annotation.Resource;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 @Profile("environment-openhab")
@@ -21,15 +23,19 @@ public class GetEventPublishingItemsRestClient {
     public List<String> asIds() {
         LOG.info("Getting all item ids tagged 'Marvin' and 'Events'");
         try {
-            List<Map> body = openhabRestClient.get()
+            return openhabRestClient.get()
                 .uri("items?tags=Marvin,Events&fields=name")
                 .retrieve()
-                .body(List.class);
-            return body.stream().map(item -> (String) item.get("name")).toList();
+                .body(LIST_OF_MAP_TYPE)
+                .stream()
+                .map(item -> item.get("name"))
+                .toList();
         } catch (HttpClientErrorException e) {
             LOG.error("Error: " + e.getMessage());
         }
         return List.of();
     }
 
+    private static final ParameterizedTypeReference<List<Map<String, String>>> LIST_OF_MAP_TYPE =
+        new ParameterizedTypeReference<>() {};
 }

--- a/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/restclient/GetStaticItemsRestClient.java
+++ b/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/restclient/GetStaticItemsRestClient.java
@@ -1,14 +1,16 @@
 package com.assetvisor.marvin.environment.openhab.restclient;
 
 import jakarta.annotation.Resource;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 @Profile("environment-openhab")
@@ -21,14 +23,16 @@ public class GetStaticItemsRestClient {
     public List<Map<String, Object>> asMaps() {
         LOG.info("Getting static information for all items tagged 'Marvin'");
         try {
-            List<Map<String, Object>> body = openhabRestClient.get()
+            return openhabRestClient.get()
                 .uri("items?tags=Marvin&staticDataOnly=true")
                 .retrieve()
-                .body(List.class);
-            return body;
+                .body(LIST_OF_MAP_TYPE);
         } catch (HttpClientErrorException e) {
             LOG.error("Error: " + e.getMessage());
         }
         return List.of();
     }
+
+    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_OF_MAP_TYPE =
+        new ParameterizedTypeReference<>() {};
 }

--- a/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/restclient/GetStaticRulesRestClient.java
+++ b/marvin.environment.openhab/src/main/java/com/assetvisor/marvin/environment/openhab/restclient/GetStaticRulesRestClient.java
@@ -1,14 +1,16 @@
 package com.assetvisor.marvin.environment.openhab.restclient;
 
 import jakarta.annotation.Resource;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 @Profile("environment-openhab")
@@ -24,7 +26,7 @@ public class GetStaticRulesRestClient {
             List<Map<String, Object>> body = openhabRestClient.get()
                 .uri("rules?tags=Marvin&staticDataOnly=true")
                 .retrieve()
-                .body(List.class);
+                .body(LIST_OF_MAP_TYPE);
             List<Map<String, Object>> maps = filterByTagMarvin(body);
             appendRuleInfo(maps);
             return maps;
@@ -45,4 +47,7 @@ public class GetStaticRulesRestClient {
             .filter(rule -> rule.get("tags").toString().contains("Marvin"))
             .toList();
     }
+
+    private static final ParameterizedTypeReference<List<Map<String, Object>>> LIST_OF_MAP_TYPE =
+        new ParameterizedTypeReference<>() {};
 }


### PR DESCRIPTION
Another small one, using URI path variables for injection safety and type tokens to get rid of "unchecked cast" warnings