### PR TITLE
Update Spring Boot to 3.5.5, Spring AI to 1.0.1, adapt to Tool API

### DIFF
--- a/marvin.brain.springai/pom.xml
+++ b/marvin.brain.springai/pom.xml
@@ -20,11 +20,15 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+      <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-cassandra-store-spring-boot-starter</artifactId>
+      <artifactId>spring-ai-starter-vector-store-cassandra</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.ai</groupId>
+      <artifactId>spring-ai-advisors-vector-store</artifactId>
     </dependency>
   </dependencies>
 

--- a/marvin.speech.openai/pom.xml
+++ b/marvin.speech.openai/pom.xml
@@ -20,7 +20,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.ai</groupId>
-      <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
+      <artifactId>spring-ai-starter-model-openai</artifactId>
     </dependency>
   </dependencies>
 

--- a/marvin.speech.openai/src/main/java/com/assetvisor/marvin/speech/springai/adapters/SpringAiSpeechConversionAdapter.java
+++ b/marvin.speech.openai/src/main/java/com/assetvisor/marvin/speech/springai/adapters/SpringAiSpeechConversionAdapter.java
@@ -58,7 +58,12 @@ public class SpringAiSpeechConversionAdapter implements ForConvertingTextToSpeec
             .language(environment.getProperty("marvin.language","en"))
             .build();
 
-        org.springframework.core.io.Resource audioResource = new org.springframework.core.io.ByteArrayResource(speech);
+        org.springframework.core.io.Resource audioResource = new org.springframework.core.io.ByteArrayResource(speech) {
+            @Override
+            public String getFilename() {
+                return "dummy.wav";
+            }
+        };
 
         var audioTranscriptionPrompt = new AudioTranscriptionPrompt(audioResource, transcriptionOptions);
         var response = openAiAudioTranscriptionModel.call(audioTranscriptionPrompt);

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-bom</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
     <mockito-junit-jupiter.version>5.14.2</mockito-junit-jupiter.version>
     <swagger.version>2.6.0</swagger.version>
-    <spring-boot.version>3.4.3</spring-boot.version>
+    <spring-boot.version>3.5.5</spring-boot.version>
     <spring-boot-maven-plugin.version>${spring-boot.version}</spring-boot-maven-plugin.version>
   </properties>
 
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>org.springframework.ai</groupId>
         <artifactId>spring-ai-bom</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Finally I have found some time to work on this again, but for my newest vision to be implemented I had to update to Spring AI 1.0.0 Final since the Milestones aren't available anymore. With 1.0.0 I had a NoSuchMethodError when querying the Cassandra vector store, so I updated to 1.0.1 and Spring Boot to 3.5.5 as well.

Since the Functions API was removed in Spring AI 1.0.0, this also encompasses the migration to the Tool API.